### PR TITLE
Add support for interrupt transfers on Linux

### DIFF
--- a/hid.go
+++ b/hid.go
@@ -33,6 +33,8 @@ type Device interface {
 	// Write to the device
 	// (technically a HID report with type 'feature' is send to the device)
 	WriteFeature([]byte) error
+	// Preform an interrupt transfer to the device
+	WriteInterrupt(byte, []byte) (int, error)
 }
 
 // FindDevices iterates through all devices with a given vendor and product id

--- a/hid_darwin.go
+++ b/hid_darwin.go
@@ -322,3 +322,7 @@ func (dev *osxDevice) WriteFeature(data []byte) error {
 func (dev *osxDevice) Write(data []byte) error {
 	return dev.setReport(C.kIOHIDReportTypeOutput, data)
 }
+
+func (dev *osxDevice) WriteInterrupt(endpoint byte, data []byte) (int, error) {
+	return 0, errors.New("WriteInterrupt is not implemented")
+}

--- a/hid_linux.go
+++ b/hid_linux.go
@@ -33,11 +33,9 @@ func Devices() <-chan *DeviceInfo {
 			return
 		}
 		defer C.libusb_free_device_list(devices, 1)
-
 		for _, dev := range asSlice(devices, cnt) {
 			di, err := newDeviceInfo(dev)
 			if err != nil {
-				fmt.Printf("ERROR: %s\n", err)
 				continue
 			}
 			result <- di
@@ -69,7 +67,7 @@ func (di *DeviceInfo) Open() (Device, error) {
 	for _, dev := range asSlice(devices, cnt) {
 		candidate, err := newDeviceInfo(dev)
 		if err != nil {
-			return nil, err
+			continue
 		}
 		if di.Path == candidate.Path {
 			var handle *C.libusb_device_handle

--- a/hid_linux.go
+++ b/hid_linux.go
@@ -133,14 +133,14 @@ func (dev *linuxDevice) WriteInterrupt(endpoint byte, data []byte) (int, error) 
 	if len(data) == 0 {
 		return 0, nil
 	}
-	const timeout = 1000
+	const timeout = 10000
 	var transferred C.int
 	rval := C.libusb_interrupt_transfer(dev.handle,
 		C.uchar(endpoint),
 		(*C.uchar)(&data[0]),
 		C.int(len(data)),
 		&transferred,
-		C.uint(timeout))
+		timeout)
 	if rval != 0 {
 		return 0, usbError(rval)
 	}

--- a/hid_windows.go
+++ b/hid_windows.go
@@ -78,6 +78,10 @@ func (d *winDevice) WriteFeature(data []byte) error {
 	}
 }
 
+func (d *winDevice) WriteInterrupt(endpoint byte, data []byte) (int, error) {
+	return 0, errors.New("WriteInterrupt is not implemented")
+}
+
 type callCFn func(buf unsafe.Pointer, bufSize *C.DWORD) unsafe.Pointer
 
 // simple helper function for this windows


### PR DESCRIPTION
This adds support for interrupt transfers on Linux.

I also fixed a bug where if one device couldn't be enumerated all devices were not able to be opened.
