### PR TITLE
fix GO compiler error "invalid flag" 

### DIFF
--- a/hid_darwin.go
+++ b/hid_darwin.go
@@ -1,7 +1,7 @@
 package hid
 
 /*
-#cgo LDFLAGS: -L . -L/usr/local/lib -framework CoreFoundation -framework IOKit -fconstant-cfstrings
+#cgo LDFLAGS: -L . -L/usr/local/lib -framework CoreFoundation -framework IOKit
 
 #include <IOKit/hid/IOHIDManager.h>
 #include <CoreFoundation/CoreFoundation.h>


### PR DESCRIPTION

When using the latest Go 1.14 release, the compiler did throw an error.
It seems the flag was deprecated.
I did simply remove it and it successfully compiled.

This is only relevant for the OSX specific code.

Had no chance yet to test with former go-releases.

The error is
```
go build _/Users/maki/projects/hid: invalid flag in #cgo LDFLAGS: -fconstant-cfstrings
```

I would appreciate if you could merge this in your code, because a lot of tools would benefit from it.